### PR TITLE
cmd/gendb: fix flag defaults

### DIFF
--- a/cmd/gendb/main.go
+++ b/cmd/gendb/main.go
@@ -41,8 +41,8 @@ func matchesCurrent(path string, new []osv.Entry) bool {
 }
 
 func main() {
-	tomlDir := flag.String("reports", "Directory containing toml reports", "")
-	jsonDir := flag.String("out", "Directory to write JSON database to", "")
+	tomlDir := flag.String("reports", "reports", "Directory containing toml reports")
+	jsonDir := flag.String("out", "out", "Directory to write JSON database to")
 	flag.Parse()
 
 	tomlFiles, err := ioutil.ReadDir(*tomlDir)


### PR DESCRIPTION
Looks like the usage specification is wrong.

Before:

```
$ gendb -h
Usage of gendb:
  -out string
         (default "Directory to write JSON database to")
  -reports string
         (default "Directory containing toml reports")
```

After:

```
$ gendb -h
Usage of /var/folders/j7/pvz71jxn637dqd96gm80nhwm0000gn/T/go-build330871962/b001/exe/main:
  -out string
        Directory to write JSON database to (default "out")
  -reports string
        Directory containing toml reports (default "reports")
```