### PR TITLE
fix json tests

### DIFF
--- a/osv/json_test.go
+++ b/osv/json_test.go
@@ -16,10 +16,10 @@ func TestGenerate(t *testing.T) {
 	r := report.Report{
 		Module: "example.com/vulnerable/v2",
 		AdditionalPackages: []struct {
-			Module   string
-			Package  string
-			Symbols  []string
-			Versions []report.VersionRange
+			Module   string                `yaml:",omitempty"`
+			Package  string                `yaml:",omitempty"`
+			Symbols  []string              `yaml:",omitempty"`
+			Versions []report.VersionRange `yaml:",omitempty"`
 		}{
 			{
 				Module:  "vanity.host/vulnerable",
@@ -44,9 +44,9 @@ func TestGenerate(t *testing.T) {
 		OS:          []string{"windows"},
 		Arch:        []string{"arm64"},
 		Links: struct {
-			PR      string
-			Commit  string
-			Context []string
+			PR      string   `yaml:",omitempty"`
+			Commit  string   `yaml:",omitempty"`
+			Context []string `yaml:",omitempty"`
 		}{
 			PR:      "pr",
 			Commit:  "commit",


### PR DESCRIPTION
Before:

```
$ go test ./...
# golang.org/x/vulndb/osv [golang.org/x/vulndb/osv.test]
osv/json_test.go:18:3: cannot use []struct { Module string; Package string; Symbols []string; Versions []report.VersionRange }{...} (type []struct { Module string; Package string; Symbols []string; Versions []report.VersionRange }) as type []struct { Module string "yaml:\",omitempty\""; Package string "yaml:\",omitempty\""; Symbols []string "yaml:\",omitempty\""; Versions []report.VersionRange "yaml:\",omitempty\"" } in field value
osv/json_test.go:46:3: cannot use struct { PR string; Commit string; Context []string }{...} (type struct { PR string; Commit string; Context []string }) as type struct { PR string "yaml:\",omitempty\""; Commit string "yaml:\",omitempty\""; Context []string "yaml:\",omitempty\"" } in field value
ok      golang.org/x/vulndb/client      (cached)
?       golang.org/x/vulndb/cmd/gendb   [no test files]
?       golang.org/x/vulndb/cmd/genhtml [no test files]
?       golang.org/x/vulndb/cmd/linter  [no test files]
?       golang.org/x/vulndb/cmd/report2cve      [no test files]
FAIL    golang.org/x/vulndb/osv [build failed]
?       golang.org/x/vulndb/report      [no test files]
FAIL
```

After:

```
$ go test ./...
ok      golang.org/x/vulndb/client
?       golang.org/x/vulndb/cmd/gendb   [no test files]
?       golang.org/x/vulndb/cmd/genhtml [no test files]
?       golang.org/x/vulndb/cmd/linter  [no test files]
?       golang.org/x/vulndb/cmd/report2cve      [no test files]
ok      golang.org/x/vulndb/osv 0.243s
?       golang.org/x/vulndb/report      [no test files]
```