### PR TITLE
internal: removes unused helper function isCVE

### DIFF
--- a/internal/ghsa/ghsa.go
+++ b/internal/ghsa/ghsa.go
@@ -240,12 +240,3 @@ func FetchGHSA(ctx context.Context, accessToken, ghsaID string) (_ *SecurityAdvi
 
 	return query.SA.securityAdvisory()
 }
-
-func isCVE(ids []Identifier) bool {
-	for _, id := range ids {
-		if id.Type == "CVE" {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
I guess this was attempted to be used here: https://github.com/vrnvu/vulndb/blob/b776e182e6934a1e7bcab96f018f1b26ee3f3f52/internal/ghsa/ghsa.go#L206

