### PR TITLE
Correct misinformation in GO-2025-3783

### DIFF
--- a/data/osv/GO-2025-3783.json
+++ b/data/osv/GO-2025-3783.json
@@ -7,12 +7,12 @@
     "CVE-2025-52894",
     "GHSA-prpj-rchp-9j5h"
   ],
-  "summary": "OpenBao allows cancellation of root rekey and recovery rekey operations without authentication in github.com/openbao/openbao/api",
-  "details": "OpenBao allows cancellation of root rekey and recovery rekey operations without authentication in github.com/openbao/openbao/api.\n\nNOTE: The source advisory for this report contains additional versions that could not be automatically mapped to standard Go module versions.\n\n(If this is causing false-positive reports from vulnerability scanners, please suggest an edit to the report.)\n\nThe additional affected modules and versions are: .",
+  "summary": "OpenBao allows cancellation of root rekey and recovery rekey operations without authentication in github.com/openbao/openbao.",
+  "details": "OpenBao allows cancellation of root rekey and recovery rekey operations without authentication in github.com/openbao/openbao.\n\nNOTE: The source advisory for this report contains additional versions that could not be automatically mapped to standard Go module versions.\n\n(If this is causing false-positive reports from vulnerability scanners, please suggest an edit to the report.)\n\nThe additional affected modules and versions are: github.com/openbao/openbao from v0.0.0 before v2.3.1.",
   "affected": [
     {
       "package": {
-        "name": "github.com/openbao/openbao/api",
+        "name": "github.com/openbao/openbao",
         "ecosystem": "Go"
       },
       "ranges": [
@@ -21,26 +21,6 @@
           "events": [
             {
               "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
-        "name": "github.com/openbao/openbao/api/v2",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "2.3.1"
             }
           ]
         }
@@ -51,7 +31,10 @@
             "type": "ECOSYSTEM",
             "events": [
               {
-                "introduced": "2.2.2"
+                "introduced": "0.0.0"
+              },
+              {
+                "fixed": "2.3.1"
               }
             ]
           }
@@ -69,7 +52,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-52894"
     },
     {
-      "type": "WEB",
+      "type": "FIX",
       "url": "https://github.com/openbao/openbao/commit/fe75468822a22a88318c6079425357a02ae5b77b"
     },
     {

--- a/data/reports/GO-2025-3783.yaml
+++ b/data/reports/GO-2025-3783.yaml
@@ -1,16 +1,13 @@
 id: GO-2025-3783
 modules:
-    - module: github.com/openbao/openbao/api
-      vulnerable_at: 1.12.2
-    - module: github.com/openbao/openbao/api/v2
-      versions:
-        - fixed: 2.3.1
+    - module: github.com/openbao/openbao
       non_go_versions:
-        - introduced: 2.2.2
-      vulnerable_at: 2.3.0
+        - introduced: 0.0.0
+        - fixed: 2.3.1
+      vulnerable_at: 0.0.0
 summary: |-
     OpenBao allows cancellation of root rekey and recovery rekey operations without
-    authentication in github.com/openbao/openbao/api
+    authentication in github.com/openbao/openbao.
 cves:
     - CVE-2025-52894
 ghsas:
@@ -18,7 +15,7 @@ ghsas:
 references:
     - advisory: https://github.com/openbao/openbao/security/advisories/GHSA-prpj-rchp-9j5h
     - advisory: https://nvd.nist.gov/vuln/detail/CVE-2025-52894
-    - web: https://github.com/openbao/openbao/commit/fe75468822a22a88318c6079425357a02ae5b77b
+    - fix: https://github.com/openbao/openbao/commit/fe75468822a22a88318c6079425357a02ae5b77b
     - web: https://github.com/openbao/openbao/releases/tag/v2.3.1
     - web: https://openbao.org/docs/deprecation
     - web: https://openbao.org/docs/deprecation/unauthed-rekey


### PR DESCRIPTION
This vulnerability was incorrectly edited by GitHub staff without consulting the project. As noted in the original report, this affects the rotation endpoints on the server: it does not impact the client API package in any way.

This vulnerability was original to HashiCorp Vault thus the initial affected version is 0 (present in all earlier OpenBao versions).

The server is not directly importable and should not be consumed by third-parties except through a release.

See also: https://github.com/openbao/openbao/security/advisories/GHSA-prpj-rchp-9j5h
See also: https://github.com/github/advisory-database/pull/5990
Resolves: https://github.com/golang/vulndb/issues/3877