### PR TITLE
chore: add fix version for GO-2022-0635, GO-2022-0646

### DIFF
--- a/data/osv/GO-2022-0635.json
+++ b/data/osv/GO-2022-0635.json
@@ -21,6 +21,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.33.0"
             }
           ]
         }

--- a/data/osv/GO-2022-0646.json
+++ b/data/osv/GO-2022-0646.json
@@ -21,6 +21,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "1.33.0"
             }
           ]
         }


### PR DESCRIPTION
### Summary
- A fix for this issue shipped in aws-sdk-go v1.33 (https://github.com/aws/aws-sdk-go/pull/3403). 
- Even the repository has archived, we should still let the user know this has been fixed in 1.33.