### PR TITLE
GO-2026-4550 only affects github.com/cloudflare/circl/ecc/p384

### DIFF
--- a/data/reports/GO-2026-4550.yaml
+++ b/data/reports/GO-2026-4550.yaml
@@ -4,6 +4,8 @@ modules:
       versions:
         - fixed: 1.6.3
       vulnerable_at: 1.6.2
+      packages:
+          - package: github.com/cloudflare/circl/ecc/p384
 summary: CIRCL has an incorrect calculation in secp384r1 CombinedMult in github.com/cloudflare/circl
 cves:
     - CVE-2026-1229


### PR DESCRIPTION
Based on available information I can access in the GitHub repository for this module, https://github.com/cloudflare/circl/pull/583 appears to be the fix for this advisory.

That changeset only affected code in this package, so I believe that only programs with this specific package in their dependency graph can potentially be affected by it.

I am not affiliated with the `github.com/cloudflare/circl` module. I am submitting this based on my own research only in the hope of reducing false-positives from `govulncheck`.
