### PR TITLE
data/reports: update GO-2026-4514 jsonparser vulnerability

### DIFF
--- a/data/reports/GO-2026-4514.yaml
+++ b/data/reports/GO-2026-4514.yaml
@@ -1,7 +1,7 @@
 id: GO-2026-4514
 modules:
     - module: github.com/buger/jsonparser
-     versions:
+      versions:
         - fixed: 1.1.2
       vulnerable_at: 1.1.1
       packages:

--- a/data/reports/GO-2026-4514.yaml
+++ b/data/reports/GO-2026-4514.yaml
@@ -1,8 +1,8 @@
 id: GO-2026-4514
 modules:
     - module: github.com/buger/jsonparser
-      non_go_versions:
-        - introduced: 0.0.0
+     versions:
+        - fixed: 1.1.2
       vulnerable_at: 1.1.1
       packages:
         - package: github.com/buger/jsonparser
@@ -17,6 +17,8 @@ description: |-
     allowing a denial of service attack.
 references:
     - report: https://github.com/buger/jsonparser/issues/275
+    - fix: https://github.com/buger/jsonparser/pull/276
+    - fix: https://github.com/buger/jsonparser/commit/d3eacc0bab77edfa15fe20d1d709e1e0080e9983
     - report: https://github.com/golang/vulndb/issues/4514
 cve_metadata:
     id: CVE-2026-32285


### PR DESCRIPTION
The fix for https://github.com/advisories/GHSA-6g7g-w4f8-9c9x (negative slice index panic in Delete) was merged in https://github.com/buger/jsonparser/pull/276 and released as v1.1.2 on 2026-03-19.

The report previously listed non_go_versions: [{introduced: 0.0.0}] with no known fix, causing vulnerability scanners to flag all versions including v1.1.2 which contains the fix.

This change:

Replaces non_go_versions with versions: [{fixed: 1.1.2}]
Adds fix: references to the PR and commit that resolved the issue
Updates https://github.com/golang/vulndb/issues/4514