### PR TITLE
data/reports/GO-2026-4772.yaml: mark fixed in v5.9.0

### DIFF
--- a/data/reports/GO-2026-4772.yaml
+++ b/data/reports/GO-2026-4772.yaml
@@ -1,7 +1,9 @@
 id: GO-2026-4772
 modules:
     - module: github.com/jackc/pgx/v5
-      vulnerable_at: 5.9.1
+      versions:
+        - fixed: 5.9.0
+      vulnerable_at: 5.8.0
       packages:
         - package: github.com/jackc/pgx/v5/pgproto3
           symbols:


### PR DESCRIPTION
Addresses #4944.

The vulnerability covered by GO-2026-4772 / CVE-2026-33816 was fixed in `github.com/jackc/pgx/v5` v5.9.0. Without a `versions:` stanza on the module, the current report treats every version as vulnerable, so govulncheck flags v5.9.0 and v5.9.1 as well.

Fix commits on `master`, all present in tags v5.9.0 and v5.9.1 (verified with `git tag --contains`):

- jackc/pgx@6dbad4c — `pgproto3: guard Bind.Decode against malformed msgSize`
- jackc/pgx@025d48c — `pgproto3: guard FunctionCall.Decode against negative argumentLength`
- jackc/pgx@9844024 — `pgproto3: bounds-check FunctionCall.Decode nArgumentCodes`

Changes:

- Add `versions: - fixed: 5.9.0` to the `github.com/jackc/pgx/v5` module.
- Adjust `vulnerable_at` from `5.9.1` to `5.8.0` so it falls inside the vulnerable range.

Lint passes locally (`go run ./cmd/vulnreport lint data/reports/GO-2026-4772.yaml`).