### PR TITLE
data/reports/GO-2026-4771.yaml: mark fixed in v5.9.0

### DIFF
--- a/data/reports/GO-2026-4771.yaml
+++ b/data/reports/GO-2026-4771.yaml
@@ -3,7 +3,7 @@ modules:
     - module: github.com/jackc/pgx/v5
       versions:
         - fixed: 5.9.0
-      vulnerable_at: 5.8.0
+      vulnerable_at: v5.0.0-alpha.1
       packages:
         - package: github.com/jackc/pgx/v5/pgproto3
           symbols:

--- a/data/reports/GO-2026-4771.yaml
+++ b/data/reports/GO-2026-4771.yaml
@@ -1,7 +1,9 @@
 id: GO-2026-4771
 modules:
     - module: github.com/jackc/pgx/v5
-      vulnerable_at: 5.9.1
+      versions:
+        - fixed: 5.9.0
+      vulnerable_at: 5.8.0
       packages:
         - package: github.com/jackc/pgx/v5/pgproto3
           symbols:

--- a/data/reports/GO-2026-4771.yaml
+++ b/data/reports/GO-2026-4771.yaml
@@ -3,7 +3,7 @@ modules:
     - module: github.com/jackc/pgx/v5
       versions:
         - fixed: 5.9.0
-      vulnerable_at: v5.0.0-alpha.1
+      vulnerable_at: 5.0.0-alpha.1
       packages:
         - package: github.com/jackc/pgx/v5/pgproto3
           symbols:


### PR DESCRIPTION
Addresses https://github.com/golang/vulndb/issues/4943

This change was omitted in pull #4955 but was described there.
The fix is seen in releases 5.9.0 and 5.9.1. 

Validated by `git tag --contains 6dbad4cafdb8a4daab7ff79c858c95da4b6109e8`
For change implemented in
https://github.com/jackc/pgx/commit/6dbad4cafdb8a4daab7ff79c858c95da4b6109e8

Changes are the similar as done for GO-2026-4772 in #4955 but for GO-2026-4771:
- Add `versions: - fixed: 5.9.0`to the `github.com/jackc/pgx/v5` module.
- Adjust `vulnerable_at` from `5.9.1` to `v5.0.0-alpha.1`.

Commit hash `d25abf56747f299c190301717e7f022b7e78dbbb`
was the earliest commit showing this omitted size check.
`5.0.0-alpha.1` being the earliest release containing it was validated with it topping
`git tag --contains d25abf56747f299c190301717e7f022b7e78dbbb --sort=creatordate`
 
