### PR TITLE
data/reports: add fixed non-Go version for GO-2026-4610

### DIFF
--- a/data/osv/GO-2026-4610.json
+++ b/data/osv/GO-2026-4610.json
@@ -43,6 +43,9 @@
             "events": [
               {
                 "introduced": "19.03.0+incompatible"
+              },
+              {
+                "fixed": "29.2.0+incompatible"
               }
             ]
           }

--- a/data/reports/GO-2026-4610.yaml
+++ b/data/reports/GO-2026-4610.yaml
@@ -5,6 +5,7 @@ modules:
         - fixed: 29.2.0+incompatible
       non_go_versions:
         - introduced: 19.03.0+incompatible
+          fixed: 29.2.0+incompatible
       vulnerable_at: 29.2.0-rc.2+incompatible
       packages:
         - package: github.com/docker/cli/cli-plugins/manager


### PR DESCRIPTION
Add the corresponding fixed version to the non_go_versions range. This
helps avoid false positives for consumers of the non-Go version range.
