### PR TITLE
data/reports: set fixed version for GO-2025-3824

### DIFF
--- a/data/osv/GO-2025-3824.json
+++ b/data/osv/GO-2025-3824.json
@@ -21,6 +21,9 @@
           "events": [
             {
               "introduced": "0"
+            },
+            {
+              "fixed": "0.14.3"
             }
           ]
         }
@@ -35,6 +38,10 @@
     },
     {
       "type": "FIX",
+      "url": "https://github.com/ollama/ollama/pull/13738"
+    },
+    {
+      "type": "WEB",
       "url": "https://github.com/ollama/ollama/pull/10750"
     },
     {

--- a/data/reports/GO-2025-3824.yaml
+++ b/data/reports/GO-2025-3824.yaml
@@ -1,7 +1,9 @@
 id: GO-2025-3824
 modules:
     - module: github.com/ollama/ollama
-      vulnerable_at: 0.9.6
+      versions:
+        - fixed: 0.14.3
+      vulnerable_at: 0.14.2
 summary: Ollama vulnerable to Cross-Domain Token Exposure in github.com/ollama/ollama
 cves:
     - CVE-2025-51471
@@ -9,10 +11,9 @@ ghsas:
     - GHSA-x9hg-5q6g-q3jr
 references:
     - advisory: https://github.com/advisories/GHSA-x9hg-5q6g-q3jr
-    - fix: https://github.com/ollama/ollama/pull/10750
+    - fix: https://github.com/ollama/ollama/pull/13738
+    - web: https://github.com/ollama/ollama/pull/10750
     - web: https://www.gecko.security/blog/cve-2025-51471
-notes:
-    - No patched version specified.
 source:
     id: GHSA-x9hg-5q6g-q3jr
     created: 2025-07-29T19:52:53.151393256Z


### PR DESCRIPTION
GO-2025-3824 (CVE-2025-51471, Ollama cross-domain token exposure) has no
`fixed` version, only `introduced: 0`, and the report notes "No patched
version specified". As a result `govulncheck` and pkg.go.dev report the
vulnerability against every version of `github.com/ollama/ollama`,
including current releases such as
[v0.32.4](https://pkg.go.dev/github.com/ollama/ollama@v0.32.4/api). The
upstream source advisory GHSA-x9hg-5q6g-q3jr carries only
`last_affected: 0.9.6`, which is why no fix was recorded.

The vulnerability has been fixed upstream.

### Evidence

The advisory describes a missing same-host check in
`server.auth.getAuthorizationToken`: the `realm` URL from a
`WWW-Authenticate` header is followed without verifying it belongs to the
host of the original request.

That check was added in
[ollama/ollama#13738](https://github.com/ollama/ollama/pull/13738)
("server: reject unexpected auth hosts"), merged 2026-01-16 as commit
[7601f0e](https://github.com/ollama/ollama/commit/7601f0e93e53858f09136a7e4ccf674a9b4580bd):

```go
 func getAuthorizationToken(ctx context.Context, challenge registryChallenge, originalHost string) (string, error) {
 	redirectURL, err := challenge.URL()
 	if err != nil {
 		return "", err
 	}

+	// Validate that the realm host matches the original request host to prevent sending tokens cross-origin.
+	if redirectURL.Host != originalHost {
+		return "", fmt.Errorf("realm host %q does not match original host %q", redirectURL.Host, originalHost)
+	}
```

`server/auth.go` is byte-identical between `v0.9.6` and `v0.14.2`, so no
earlier release carried the check, and `v0.14.3` is the first release
tag containing the fix commit:

```
$ git ls-tree v0.9.6  server/ | grep auth.go
100644 blob dcef5bf9cc249e624758551a384646d28e7c2c57	server/auth.go
$ git ls-tree v0.14.2 server/ | grep auth.go
100644 blob dcef5bf9cc249e624758551a384646d28e7c2c57	server/auth.go

$ git tag --contains 7601f0e93e53858f09136a7e4ccf674a9b4580bd | grep -v rc | sort -V | head -1
v0.14.3
```

The affected range is therefore `[0, 0.14.3)`, and `vulnerable_at` is
updated to `0.14.2` accordingly.

### Also in this change

The existing `fix:` reference pointed at
[ollama/ollama#10750](https://github.com/ollama/ollama/pull/10750), which
is the reporter's proposed patch and was closed unmerged. It is demoted
to a `web:` reference and #13738 is recorded as the fix.

`data/osv/GO-2025-3824.json` was regenerated with
`go run ./cmd/vulnreport fix data/reports/GO-2025-3824.yaml`; `vulnreport
lint` passes.

I have also opened
[github/advisory-database#8826](https://github.com/github/advisory-database/pull/8826)
to correct the source GHSA record.
