### PR TITLE
data/reports: update 5 Traefik reports to v3-only modules

### DIFF
--- a/data/osv/GO-2025-4205.json
+++ b/data/osv/GO-2025-4205.json
@@ -12,40 +12,6 @@
   "affected": [
     {
       "package": {
-        "name": "github.com/traefik/traefik",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
-        "name": "github.com/traefik/traefik/v2",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
         "name": "github.com/traefik/traefik/v3",
         "ecosystem": "Go"
       },

--- a/data/osv/GO-2026-4484.json
+++ b/data/osv/GO-2026-4484.json
@@ -12,40 +12,6 @@
   "affected": [
     {
       "package": {
-        "name": "github.com/traefik/traefik",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
-        "name": "github.com/traefik/traefik/v2",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
         "name": "github.com/traefik/traefik/v3",
         "ecosystem": "Go"
       },

--- a/data/osv/GO-2026-4880.json
+++ b/data/osv/GO-2026-4880.json
@@ -12,40 +12,6 @@
   "affected": [
     {
       "package": {
-        "name": "github.com/traefik/traefik",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
-        "name": "github.com/traefik/traefik/v2",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
         "name": "github.com/traefik/traefik/v3",
         "ecosystem": "Go"
       },

--- a/data/osv/GO-2026-5083.json
+++ b/data/osv/GO-2026-5083.json
@@ -12,40 +12,6 @@
   "affected": [
     {
       "package": {
-        "name": "github.com/traefik/traefik",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
-        "name": "github.com/traefik/traefik/v2",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
         "name": "github.com/traefik/traefik/v3",
         "ecosystem": "Go"
       },

--- a/data/osv/GO-2026-5128.json
+++ b/data/osv/GO-2026-5128.json
@@ -12,40 +12,6 @@
   "affected": [
     {
       "package": {
-        "name": "github.com/traefik/traefik",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
-        "name": "github.com/traefik/traefik/v2",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
         "name": "github.com/traefik/traefik/v3",
         "ecosystem": "Go"
       },

--- a/data/reports/GO-2025-4205.yaml
+++ b/data/reports/GO-2025-4205.yaml
@@ -1,9 +1,5 @@
 id: GO-2025-4205
 modules:
-    - module: github.com/traefik/traefik
-      vulnerable_at: 1.7.34
-    - module: github.com/traefik/traefik/v2
-      vulnerable_at: 2.11.32
     - module: github.com/traefik/traefik/v3
       versions:
         - introduced: 3.5.0

--- a/data/reports/GO-2026-4484.yaml
+++ b/data/reports/GO-2026-4484.yaml
@@ -1,9 +1,5 @@
 id: GO-2026-4484
 modules:
-    - module: github.com/traefik/traefik
-      vulnerable_at: 1.7.34
-    - module: github.com/traefik/traefik/v2
-      vulnerable_at: 2.11.37
     - module: github.com/traefik/traefik/v3
       versions:
         - fixed: 3.6.8

--- a/data/reports/GO-2026-4880.yaml
+++ b/data/reports/GO-2026-4880.yaml
@@ -1,11 +1,5 @@
 id: GO-2026-4880
 modules:
-    - module: github.com/traefik/traefik
-      vulnerable_at: 1.7.34
-    - module: github.com/traefik/traefik/v2
-      unsupported_versions:
-        - last_affected: 2.11.42
-      vulnerable_at: 2.11.42
     - module: github.com/traefik/traefik/v3
       versions:
         - fixed: 3.6.11

--- a/data/reports/GO-2026-5083.yaml
+++ b/data/reports/GO-2026-5083.yaml
@@ -1,13 +1,5 @@
 id: GO-2026-5083
 modules:
-    - module: github.com/traefik/traefik
-      unsupported_versions:
-        - last_affected: 1.7.34
-      vulnerable_at: 1.7.34
-    - module: github.com/traefik/traefik/v2
-      unsupported_versions:
-        - last_affected: 2.11.50
-      vulnerable_at: 2.11.50
     - module: github.com/traefik/traefik/v3
       versions:
         - fixed: 3.6.21

--- a/data/reports/GO-2026-5128.yaml
+++ b/data/reports/GO-2026-5128.yaml
@@ -1,9 +1,5 @@
 id: GO-2026-5128
 modules:
-    - module: github.com/traefik/traefik
-      vulnerable_at: 1.7.34
-    - module: github.com/traefik/traefik/v2
-      vulnerable_at: 2.11.50
     - module: github.com/traefik/traefik/v3
       versions:
         - introduced: 3.7.0-ea.1


### PR DESCRIPTION
  - data/reports/GO-2025-4205.yaml
  - data/reports/GO-2026-4484.yaml
  - data/reports/GO-2026-4880.yaml
  - data/reports/GO-2026-5083.yaml
  - data/reports/GO-2026-5128.yaml

These five reports list github.com/traefik/traefik and
github.com/traefik/traefik/v2 with no versions block, which marks every
v1 and v2 version affected with no fixed version. All five
vulnerabilities are in code that exists only in v3, so users on the
current v2 LTS (v2.11.54) match permanently and no upgrade clears the
finding. The upstream GitHub advisories scope to
github.com/traefik/traefik/v3 only.

GO-2025-4205 (CVE-2025-66491) and GO-2026-5128 (CVE-2026-54762) are in
the Kubernetes ingress-nginx provider, which was added in v3.5.0. The
directory does not exist in v2:

    git ls-tree -d --name-only v2.11.54 \
        pkg/provider/kubernetes/ingress-nginx

GO-2026-4880 (CVE-2026-32695) is in the Knative provider, which is
likewise absent from v2 (pkg/provider/kubernetes/knative).

GO-2026-4484 (CVE-2026-25949) is in the TCP STARTTLS handling for
Postgres; pkg/server/router/tcp/postgres.go does not exist in v2.

GO-2026-5083 (CVE-2026-54761) needs more than a file check, since v2
does ship a Kubernetes Gateway provider. The vulnerability is that the
crossProviderNamespaces allowlist was checked against
backendRef.Namespace rather than the route's own namespace, for
HTTPRoute rules with several (WRR) backendRefs. In v2.11.54, in
pkg/provider/kubernetes/gateway/kubernetes.go, neither precondition
holds: internal services are rejected outright in a WRR, and the
allowlist is checked against the route namespace. This is a claim about
that specific defect, not a general statement about the v2 provider.

GO-2026-4679 (CVE-2026-29777) carries the same v1 and v2 module entries
but is not included here; its module list is still under review and
will be corrected in a follow-up.

data/osv was regenerated with vulnreport osv. review_status is left at
UNREVIEWED on all five reports.

Updates golang/vulndb#4205
Updates golang/vulndb#4484
Updates golang/vulndb#4880
Updates golang/vulndb#5083
Updates golang/vulndb#5128
