### PR TITLE
data/reports: fix GO-2026-5064, remove incorrect unversioned v1 containerd entry

### DIFF
--- a/data/osv/GO-2026-5064.json
+++ b/data/osv/GO-2026-5064.json
@@ -12,23 +12,6 @@
   "affected": [
     {
       "package": {
-        "name": "github.com/containerd/containerd",
-        "ecosystem": "Go"
-      },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
-      "ecosystem_specific": {}
-    },
-    {
-      "package": {
         "name": "github.com/containerd/containerd/v2",
         "ecosystem": "Go"
       },

--- a/data/reports/GO-2026-5064.yaml
+++ b/data/reports/GO-2026-5064.yaml
@@ -1,7 +1,5 @@
 id: GO-2026-5064
 modules:
-    - module: github.com/containerd/containerd
-      vulnerable_at: 1.7.33
     - module: github.com/containerd/containerd/v2
       versions:
         - introduced: 2.1.0


### PR DESCRIPTION
Fixes #5780.

`github.com/containerd/containerd` (v1, pre-`/v2` rename) was listed with only `vulnerable_at: 1.7.33` and no `versions:`. Per `doc/format.md`, omitting `versions` means "every version of the module is vulnerable, no known fix" — that's what was producing the reported "all versions, unfixed" classification. It's visible concretely in the previously-generated OSV record: an unbounded `"introduced": "0"` range for the v1 package with no matching fix event.

This isn't just imprecise, it's incorrect:
- The GHSA ([GHSA-33vj-92qq-66hc](https://github.com/advisories/GHSA-33vj-92qq-66hc)) and containerd's own advisory list only `github.com/containerd/containerd/v2`, with ranges 2.1.0–2.1.9, 2.2.0–2.2.5, 2.3.0–2.3.2.
- The vulnerable functionality — CRI-level checkpoint/restore — was introduced in containerd **v2.1.0** ("Support container restore through CRI/Kubernetes", containerd/containerd#10365) and does not exist in the 1.x line at all, so v1 isn't "affected with an unknown fix" — it's simply not affected.
- `doc/format.md` documents no `unaffected`/`not_affected` field; the convention for a module that isn't hit is to omit its entry, which this PR does.

`data/osv/GO-2026-5064.json` was regenerated via `vulnreport osv` to match; no other fields changed.