### PR TITLE
data/reports/GO-2026-5287.yaml: fix branch versions and symbols

### DIFF
--- a/data/osv/GO-2026-5287.json
+++ b/data/osv/GO-2026-5287.json
@@ -40,7 +40,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "2.11.51"
+              "fixed": "2.11.48"
             }
           ]
         }
@@ -50,8 +50,7 @@
           {
             "path": "github.com/traefik/traefik/v2/pkg/server/router/tcp",
             "symbols": [
-              "Router.GetTLSGetClientInfo",
-              "Router.HTTP3TLSConfigMatcherFunc"
+              "Router.GetTLSGetClientInfo"
             ]
           }
         ]
@@ -70,6 +69,12 @@
               "introduced": "0"
             },
             {
+              "fixed": "3.6.19"
+            },
+            {
+              "introduced": "3.7.0"
+            },
+            {
               "fixed": "3.7.3"
             }
           ]
@@ -80,8 +85,7 @@
           {
             "path": "github.com/traefik/traefik/v3/pkg/server/router/tcp",
             "symbols": [
-              "Router.GetTLSGetClientInfo",
-              "Router.HTTP3TLSConfigMatcherFunc"
+              "Router.GetTLSGetClientInfo"
             ]
           }
         ]
@@ -96,6 +100,14 @@
     {
       "type": "WEB",
       "url": "https://github.com/traefik/traefik/releases/tag/v3.7.3"
+    },
+    {
+      "type": "FIX",
+      "url": "https://github.com/traefik/traefik/pull/13214"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/traefik/traefik/releases/tag/v3.6.19"
     }
   ],
   "database_specific": {

--- a/data/reports/GO-2026-5287.yaml
+++ b/data/reports/GO-2026-5287.yaml
@@ -4,22 +4,22 @@ modules:
       vulnerable_at: 1.7.34
     - module: github.com/traefik/traefik/v2
       versions:
-        - fixed: 2.11.51
-      vulnerable_at: 2.11.50
+        - fixed: 2.11.48
+      vulnerable_at: 2.11.46
       packages:
         - package: github.com/traefik/traefik/v2/pkg/server/router/tcp
           symbols:
             - Router.GetTLSGetClientInfo
-            - Router.HTTP3TLSConfigMatcherFunc
     - module: github.com/traefik/traefik/v3
       versions:
-        - fixed: 3.7.3
-      vulnerable_at: 3.7.2
+        - fixed: 3.6.19
+        - introduced: 3.7.0
+          fixed: 3.7.3
+      vulnerable_at: 3.7.1
       packages:
         - package: github.com/traefik/traefik/v3/pkg/server/router/tcp
           symbols:
             - Router.GetTLSGetClientInfo
-            - Router.HTTP3TLSConfigMatcherFunc
 summary: |-
     Traefik: HTTP/3 mTLS bypass via exact SNI TLSOptions lookup for wildcard and
     mixed-case hosts in github.com/traefik/traefik
@@ -40,6 +40,8 @@ ghsas:
 references:
     - advisory: https://github.com/traefik/traefik/security/advisories/GHSA-9cr8-q42q-g8m7
     - web: https://github.com/traefik/traefik/releases/tag/v3.7.3
+    - fix: https://github.com/traefik/traefik/pull/13214
+    - web: https://github.com/traefik/traefik/releases/tag/v3.6.19
 source:
     id: GHSA-9cr8-q42q-g8m7
     created: 2026-07-22T21:46:13.165616-04:00


### PR DESCRIPTION
the fix was backported, so the single fixed: 3.7.3 range incorrectly marks patched 3.6.x releases as vulnerable, container scanners are currently flagging traefik 3.6.25 because of this

the fix is https://github.com/traefik/traefik/pull/13214, commit 5026ca97d0, it was merged into v2.11 and forward into v3.6 and v3.7, it removes router.gettlsgetclientinfo and adds router.http3tlsconfigmatcherfunc, the first tags with the new symbol are v2.11.47, v3.6.18, and v3.7.2, those releases were pulled and re-cut as 2.11.48, 3.6.19, and 3.7.3, which is what i used here.

the symbol list is the other half of the issue, router.http3tlsconfigmatcherfunc is the patched function, it was included because vulnerable_at was set to 3.7.2 and 2.11.50, but both versions already contain the fix

Cchanges:
- `/v3`: split into `fixed: 3.6.19` and `introduced: 3.7.0, fixed: 3.7.3`; `vulnerable_at` 3.7.2 -> 3.7.1
- `/v2`: `fixed` 2.11.51 -> 2.11.48; `vulnerable_at` 2.11.50 -> 2.11.46
- drop `Router.HTTP3TLSConfigMatcherFunc` from both symbol lists